### PR TITLE
fix: 修复体验问题

### DIFF
--- a/src/dashboard-front/src/common/util.ts
+++ b/src/dashboard-front/src/common/util.ts
@@ -443,6 +443,26 @@ export const getStatus = (stageData: any) => {
   return 'delist';
 };
 
+// 环境状态文字
+export const getStatusText = (status: string) => {
+  let text = '';
+  switch (status) {
+    case 'success':
+      text = '已上线';
+      break;
+    case 'unreleased':
+      text = '未发布';
+      break;
+    case 'delist':
+      text = '已下架';
+      break;
+    case 'failure':
+      text = '发布失败';
+      break;
+  }
+  return text;
+};
+
 export const json2yaml = (jsonStr: string) => {
   try {
     return {

--- a/src/dashboard-front/src/components/version-diff/index.vue
+++ b/src/dashboard-front/src/components/version-diff/index.vue
@@ -348,11 +348,18 @@
 
           <template v-if="!hasResult && !isDataLoading">
             <!-- 无数据 -->
+            <TableEmpty
+              v-if="hasFilter"
+              :keyword="tableEmptyConf.keyword"
+              :abnormal="tableEmptyConf.isAbnormal"
+              @reacquire="getDiffData"
+              @clear-filter="handleClearFilterKey"
+            />
             <bk-exception
-              class="mt50"
+              class="mt50 diff-tips"
               type="search-empty"
               scene="part"
-              v-if="!localSourceId || !localTargetId || !hasFilter"
+              v-else
             >
               {{
                 !localSourceId
@@ -362,13 +369,6 @@
                     : $t("版本资源配置无差异")
               }}
             </bk-exception>
-            <TableEmpty
-              v-else
-              :keyword="tableEmptyConf.keyword"
-              :abnormal="tableEmptyConf.isAbnormal"
-              @reacquire="getDiffData"
-              @clear-filter="handleClearFilterKey"
-            />
           </template>
         </bk-loading>
       </div>
@@ -1098,5 +1098,8 @@ onMounted(() => {
       box-shadow: none;
     }
   }
+}
+.diff-tips {
+  color: #63656E;
 }
 </style>

--- a/src/dashboard-front/src/store/resourceVersion.ts
+++ b/src/dashboard-front/src/store/resourceVersion.ts
@@ -4,6 +4,10 @@ export const useResourceVersion = defineStore('resourceVersion', {
   state: () => ({
     tabActive: 'edition',
     resourceFilter: {},
+    pageStatus: {
+      isDetail: false,
+      isShowLeft: true,
+    },
   }),
   getters: {
     getTabActive(state) {
@@ -12,6 +16,9 @@ export const useResourceVersion = defineStore('resourceVersion', {
     getResourceFilter(state) {
       return state.resourceFilter;
     },
+    getPageStatus(state) {
+      return state.pageStatus;
+    },
   },
   actions: {
     setTabActive(key: string) {
@@ -19,6 +26,9 @@ export const useResourceVersion = defineStore('resourceVersion', {
     },
     setResourceFilter(value: any) {
       this.resourceFilter = value;
+    },
+    setPageStatus(value: any) {
+      this.pageStatus = value;
     },
   },
 });

--- a/src/dashboard-front/src/views/components/plugin-manage/index.vue
+++ b/src/dashboard-front/src/views/components/plugin-manage/index.vue
@@ -316,6 +316,16 @@ const stepChanged = (index: number) => {
   if (index === 1) {
     state.curStep = index;
   }
+  if (index === 2) {
+    if (curChoosePlugin.value) {
+      state.curStep = index;
+    } else {
+      Message({
+        theme: 'warning',
+        message: '请先勾选插件',
+      });
+    }
+  }
 };
 
 const isBound = computed(() => {

--- a/src/dashboard-front/src/views/permission/app/index.vue
+++ b/src/dashboard-front/src/views/permission/app/index.vue
@@ -935,20 +935,6 @@ watch(
   min-height: 600px;
 }
 
-.auth-sideslider {
-  :deep(.bk-modal-content) {
-    padding: 30px;
-  }
-
-  :deep(.bk-radio-label) {
-    font-size: 14px !important;
-  }
-
-  .code-input {
-    width: 256px;
-  }
-}
-
 .attention-dialog {
   :deep(.bk-dialog-header) {
     padding: 5px !important;
@@ -983,6 +969,21 @@ watch(
     height: 280px;
     max-height: 280px;
     justify-content: center;
+  }
+}
+</style>
+<style lang="scss">
+.auth-sideslider {
+  .bk-modal-content {
+    padding: 30px;
+  }
+
+  .bk-radio-label {
+    font-size: 14px !important;
+  }
+
+  .code-input {
+    width: 256px;
   }
 }
 </style>

--- a/src/dashboard-front/src/views/resource/setting/comps/version-sideslider.vue
+++ b/src/dashboard-front/src/views/resource/setting/comps/version-sideslider.vue
@@ -34,7 +34,7 @@
                   theme="info"
                   :title="`${t('最新版本号')}: ${versionList[0]?.version || '--'},
                   ${t('于')} ${versionList[0]?.created_time || '--'} ${t('创建')}`"
-                  class="mt15 mb15"
+                  class="mb15"
                 />
 
                 <bk-form ref="formRef" :model="formData" :rules="rules" form-type="vertical">
@@ -306,7 +306,7 @@ defineExpose({
     }
 
     .main {
-      padding: 0 100px;
+      padding: 15px 100px 0px;
 
       .add {
         color: #34d97b;

--- a/src/dashboard-front/src/views/resource/setting/index.vue
+++ b/src/dashboard-front/src/views/resource/setting/index.vue
@@ -465,7 +465,7 @@ import ResourceSettingTopBar from '@/components/resource-setting-top-bar.vue';
 import mitt from '@/common/event-bus';
 import { IDialog, IDropList, MethodsEnum } from '@/types';
 import { is24HoursAgo } from '@/common/util';
-import {  useCommon } from '@/store';
+import {  useCommon, useResourceVersion } from '@/store';
 
 const props = defineProps({
   apigwId: {
@@ -497,6 +497,7 @@ type TableEmptyConfType = {
 const leftWidth = ref('320px');
 const methodsEnum: any = ref(MethodsEnum);
 const common = useCommon();
+const resourceVersionStore = useResourceVersion();
 const { t } = useI18n();
 // 批量下拉的item
 const batchDropData = ref([{ value: 'edit', label: '编辑资源' }, { value: 'delete', label: '删除资源' }]);
@@ -1217,6 +1218,29 @@ watch(() => route, () => {
   }
 }, { immediate: true, deep: true });
 
+watch(
+  () => [isDetail.value, isShowLeft.value],
+  () => {
+    resourceVersionStore.setPageStatus({
+      isDetail: isDetail.value,
+      isShowLeft: isShowLeft.value,
+    });
+  },
+);
+
+const recoverPageStatus = () => {
+  const { isDetail: d, isShowLeft: l } = resourceVersionStore.getPageStatus;
+  isDetail.value = d;
+  isShowLeft.value = l;
+
+  const el = document.getElementById('resourceLf');
+  if (!l) {
+    el.style.width = '0px';
+  } else {
+    el.style.width = leftWidth.value;
+  }
+};
+
 onMounted(() => {
   init();
   dragTwoColDiv('resourceId', 'resourceLf', 'resourceLine'/* , 'resourceRg' */);
@@ -1226,6 +1250,8 @@ onMounted(() => {
     getList();
     handleShowVersion();
   });
+
+  recoverPageStatus();
 });
 
 onBeforeMount(() => {

--- a/src/dashboard-front/src/views/stage/overview/comps/edit-stage-sideslider.vue
+++ b/src/dashboard-front/src/views/stage/overview/comps/edit-stage-sideslider.vue
@@ -681,7 +681,7 @@ defineExpose({
   }
 }
 .sideslider-content {
-  padding: 20px 40px;
+  padding: 20px 40px 32px;
   .host-item {
     display: flex;
     align-items: center;
@@ -811,7 +811,7 @@ defineExpose({
 .footer-btn-wrapper {
   bottom: 0;
   height: 52px;
-  padding-left: 20px;
+  padding-left: 40px;
 }
 .fixed-footer-btn-wrapper {
   position: fixed;
@@ -819,7 +819,7 @@ defineExpose({
   left: 0;
   right: 0;
   padding: 10px 0;
-  padding-left: 20px;
+  padding-left: 40px;
   background: #fff;
   box-shadow: 0 -2px 4px 0 #0000000f;
   z-index: 9;
@@ -864,7 +864,9 @@ defineExpose({
     }
     :deep(.bk-collapse-item) {
       background-color: #F5F7FB;
-      margin-bottom: 25px;
+      &:not(:nth-last-child(1)) {
+        margin-bottom: 25px;
+      }
 
       .bk-collapse-content {
         padding: 5px 32px;

--- a/src/dashboard-front/src/views/stage/overview/comps/release-sideslider.vue
+++ b/src/dashboard-front/src/views/stage/overview/comps/release-sideslider.vue
@@ -290,6 +290,8 @@ const handlePublish = async () => {
             id: 'customize',
             text: () => t('后端服务'),
             onClick: () => {
+              isShow.value = false;
+              dialogConfig.isShow = false;
               router.push({
                 name: 'apigwBackendService',
                 params: {

--- a/src/dashboard-front/src/views/stage/overview/comps/stage-card-list.vue
+++ b/src/dashboard-front/src/views/stage/overview/comps/stage-card-list.vue
@@ -4,7 +4,14 @@
       <div class="title">
         <div class="title-lf">
           <spinner v-if="getStatus(stageData) === 'doing'" fill="#3A84FF" />
-          <span v-else :class="['dot', getStatus(stageData)]"></span>
+          <span
+            v-else
+            :class="['dot', getStatus(stageData)]"
+            v-bk-tooltips="{
+              content: getStatusText(getStatus(stageData)),
+              disabled: !getStatusText(getStatus(stageData)) }"
+          >
+          </span>
           {{ stageData.name }}
         </div>
         <div class="title-rg">
@@ -120,7 +127,7 @@ import { useI18n } from 'vue-i18n';
 import { Message, InfoBox } from 'bkui-vue';
 import { Spinner } from 'bkui-vue/lib/icon';
 
-import { copy, getStatus } from '@/common/util';
+import { copy, getStatus, getStatusText } from '@/common/util';
 import logDetails from '@/components/log-details/index.vue';
 import mitt from '@/common/event-bus';
 import { useGetGlobalProperties } from '@/hooks';
@@ -406,7 +413,7 @@ onUnmounted(() => {
     width: 8px;
     height: 8px;
     border-radius: 50%;
-
+    cursor: pointer;
     &.success {
       border: 1px solid #3FC06D;
       background: #E5F6EA;

--- a/src/dashboard-front/src/views/stage/overview/detail-mode/resource-info.vue
+++ b/src/dashboard-front/src/views/stage/overview/detail-mode/resource-info.vue
@@ -464,6 +464,14 @@ onMounted(() => {
   height: 420px;
   display: flex;
   align-items: center;
+  :deep(.bk-exception-description) {
+    font-size: 14px;
+    margin-top: 0px;
+  }
+  :deep(.bk-exception-img) {
+    width: 220px;
+    height: 130px;
+  }
 }
 .plugin-tag {
   display: inline-block;


### PR DESCRIPTION
Fixes # (issue)
- 【必须】而且点报错中的“后端配置”后，主页面切换到后端管理页面，但刚才发布的侧滑和弹框还在，而且无法正常关闭，只能通过浏览器reload页面，这里处理的太糙了
- 【必须】主动授权页面前端CSS问题
- 【必须】搜索为空时，提示错误，应该是搜索为空的提示，且提示的字体颜色为：#63656E
- 【必须】点击上面的步骤可以切换
- 【必须】点击批量编辑后 成功后应该返回当前 页面，而不是列表页面
- 【必须】按钮对齐和间距问题
- 【必须】版本号离顶部的横线是不是太近了？加点留白？
- 【必须】资源信息和插件管理 无数据时的占位图标大小及字号不同
- 【必须】这个灰点是什么含义？应该tooltip说明
- 这里还有很多空间可以显示，需要根据屏幕自适应