### PR TITLE
fix: 修复体验问题

### DIFF
--- a/src/dashboard-front/src/language/lang.ts
+++ b/src/dashboard-front/src/language/lang.ts
@@ -1355,7 +1355,11 @@ const lang: ILANG = {
   '请输入 SDK 版本号': ['Please enter the SDK version number'],
   'SDK仅包含公开资源，生成后会上传到pypi源或bkrepo': ['The SDK only includes public resources, and will be uploaded to the PyPI or BKRepo source after generation'],
   '生成语言': ['Generation language'],
-
+  '编辑后端服务': ['Edit back-end services'],
+  '去查看发布记录': ['Go to the release record'],
+  '后端服务内容保存成功，正在发布到对应的环境': ['The back-end service content is saved successfully and is being published to the corresponding environment'],
+  '当前后端服务（{name}）已绑定以下 {num} 个环境，所有修改都将发布到这些环境中：{names}': ['The current backend service ({name}) has bound the following {num} environments to which all changes will be published: {names}'],
+  '网关环境【prod】中的配置【后端服务地址】不合法。请在网关 `后端服务` 中进行配置。': ['The back-end service address configured in gateway environment prod is invalid. Please configure in Gateway back-end services.'],
   '最大 300s': ['Maximum 300s'],
   '恢复初始值': ['Reset to default'],
   '请输入超时时间': ['Please enter the timeout period'],

--- a/src/dashboard-front/src/views/backend-service/add.vue
+++ b/src/dashboard-front/src/views/backend-service/add.vue
@@ -384,18 +384,35 @@ const handleConfirm = async () => {
     }
     if (isPublish.value && props.editId) {
       sidesliderConfi.isShow = false;
-      InfoBox({
-        title: t('内容保存成功，正在发布至环境中'),
-        infoType: 'success',
-        subTitle: t('如果编辑的后端服务绑定的环境有发布就会立即发布到对应环境当中'),
-        confirmText: t('去查看'),
-        cancelText: t('关闭'),
-        onConfirm: () => {
-          router.push({
-            name: 'apigwReleaseHistory',
-          });
-        },
+
+      const stageNames = stageConfig.value?.map((item: any) => {
+        return item.name;
       });
+
+      if (stageNames?.length) {
+        InfoBox({
+          title: t('后端服务内容保存成功，正在发布到对应的环境'),
+          infoType: 'success',
+          width: 482,
+          subTitle: t('当前后端服务（{name}）已绑定以下 {num} 个环境，所有修改都将发布到这些环境中：{names}', { name: baseInfo.value.name, num: stageNames?.length, names: stageNames?.join('，') }),
+          confirmText: t('去查看发布记录'),
+          cancelText: t('关闭'),
+          onConfirm: () => {
+            router.push({
+              name: 'apigwReleaseHistory',
+            });
+          },
+        });
+      } else {
+        InfoBox({
+          title: t('后端服务内容保存成功'),
+          infoType: 'success',
+          dialogType: 'confirm',
+          headerAlign: 'center',
+          footerAlign: 'center',
+          confirmText: t('关闭'),
+        });
+      }
     } else {
       Message({
         message: !props.editId ? t('新建成功') : t('更新成功'),

--- a/src/dashboard-front/src/views/basic-info/common/type.ts
+++ b/src/dashboard-front/src/views/basic-info/common/type.ts
@@ -15,6 +15,7 @@ export interface BasicInfoParams {
   created_time: string
   public_key: string
   is_official: boolean
+  publish_validate_msg: string
 }
 
 export interface DialogParams {

--- a/src/dashboard-front/src/views/resource/setting/comps/select-check-box.vue
+++ b/src/dashboard-front/src/views/resource/setting/comps/select-check-box.vue
@@ -140,6 +140,10 @@ watch(curLabelIds, () => {
 
 //
 const handleToggle = async (v: boolean) => {
+  if (!v) {
+    showEdit.value = false;
+    optionName.value = '';
+  }
   // 新增标签标识
   if (isAdd.value) return;
   setTimeout(async () => {

--- a/src/dashboard-front/src/views/resource/version/edition/index.vue
+++ b/src/dashboard-front/src/views/resource/version/edition/index.vue
@@ -98,7 +98,9 @@
                       <bk-dropdown-item
                         v-for="item in stageList"
                         :key="item.id"
-                        @click="handleClickStage(item, data)"
+                        @click="!item.publish_validate_msg ? handleClickStage(item, data) : ''"
+                        :class="{ 'menu-item-disabled': !!item.publish_validate_msg }"
+                        v-bk-tooltips="{ content: t(item.publish_validate_msg), disabled: !item.publish_validate_msg }"
                       >
                         {{ item.name }}
                       </bk-dropdown-item>
@@ -402,6 +404,16 @@ onUnmounted(() => {
   }
   :deep(.bk-table-body) {
     scrollbar-color: transparent transparent;
+  }
+}
+:deep(.menu-item-disabled) {
+  background-color: #dcdee5;
+  color: #fff;
+  cursor: not-allowed;
+  &:hover {
+    background-color: #dcdee5;
+    color: #fff;
+    cursor: not-allowed;
   }
 }
 </style>

--- a/src/dashboard-front/src/views/stage/overview/comps/stage-card-list.vue
+++ b/src/dashboard-front/src/views/stage/overview/comps/stage-card-list.vue
@@ -31,7 +31,8 @@
             <bk-button
               theme="primary"
               size="small"
-              :disabled="getStatus(stageData) === 'doing'"
+              :disabled="getStatus(stageData) === 'doing' || !!stageData.publish_validate_msg"
+              v-bk-tooltips="{ content: t(stageData.publish_validate_msg), disabled: !stageData.publish_validate_msg }"
               @click="handleRelease(stageData)"
             >
               {{ t('发布资源') }}
@@ -73,7 +74,7 @@
         <div class="apigw-form-item">
           <div class="label" :class="locale === 'en' ? 'en' : ''">{{ `${t('当前资源版本')}：` }}</div>
           <div class="value">
-            <span class="unrelease" v-if="stageData.release.status === 'unreleased'">{{ t('未发布') }}</span>
+            <span class="unrelease" v-if="stageData.release.status === 'unreleased'">--</span>
             <span v-else>{{ stageData.resource_version.version || '--' }}</span>
             <template v-if="getStatus(stageData) === 'doing'">
               <bk-tag theme="info">发布中</bk-tag>,

--- a/src/dashboard-front/src/views/stage/overview/detail-mode/index.vue
+++ b/src/dashboard-front/src/views/stage/overview/detail-mode/index.vue
@@ -45,7 +45,7 @@
                     class="unrelease"
                     v-if="stageData.release.status === 'unreleased'"
                   >
-                    {{ t('尚未发布') }}
+                    --
                   </span>
                   <span v-else>{{ stageData.resource_version.version || '--' }}</span>
                 </div>
@@ -85,7 +85,14 @@
               v-bk-tooltips="{ content: t('当前网关已停用，如需使用，请先启用'), delay: 300 }">
               {{ t('发布资源') }}
             </bk-button>
-            <bk-button v-else theme="primary" class="mr10" @click="handleRelease">
+            <bk-button
+              v-else
+              theme="primary"
+              class="mr10"
+              :disabled="!!stageData?.publish_validate_msg"
+              v-bk-tooltips="{ content: t(stageData?.publish_validate_msg),
+                               disabled: !stageData?.publish_validate_msg }"
+              @click="handleRelease">
               {{ t('发布资源') }}
             </bk-button>
             <bk-button
@@ -224,6 +231,7 @@ const stageData: any = computed(() => {
     },
     resource_version: '',
     new_resource_version: '',
+    publish_validate_msg: '',
   };
 });
 
@@ -380,6 +388,7 @@ const basicInfoData = ref<BasicInfoParams>({
   created_by: '',
   created_time: '',
   public_key: '',
+  publish_validate_msg: '',
   maintainers: [],
   developers: [],
   is_public: true,


### PR DESCRIPTION
Fixes # (issue)
- 【必须】【高】两句话意思自相矛盾了吧，而且下面这段需要优化，连个标点符号都没有，也比较口语化。如果一定依赖发布操作才会更新至环境，就谈不上“正在发布至环境中”。如果会自动发布至环境，那给的查看按钮要紧跟这句话，说清楚去查看
- 【必须】环境设置所必须的基本信息缺失的情况下，是否应直接禁用发布按钮
- 【必须】当前资源版本，没有时用 -- 占位符即可，不需要特殊样式
- 【必须】当失去焦点后，再次触发标签下拉框 这个创建标签的输入框不应该还激活